### PR TITLE
Bug 1736416 - Update packer win10-64-2004 config to use new deploymenent id

### DIFF
--- a/packer/config/win10-64-2004.yaml
+++ b/packer/config/win10-64-2004.yaml
@@ -23,5 +23,5 @@ vm:
         sourceOrganisation: mozilla-platform-ops
         sourceRepository: ronin_puppet
         sourceRevision: cloud_windows
-        deploymentId: 5db26eb
+        deploymentId: 7c12c58
         managed_by: packer


### PR DESCRIPTION
See https://github.com/mozilla-platform-ops/ronin_puppet/pull/360 for what has been edited.