### PR TITLE
Fix sysprep issue around windowsazuretelemetry bug

### DIFF
--- a/packer/packer-json-template.json
+++ b/packer/packer-json-template.json
@@ -138,14 +138,17 @@
         "$stage =  ((Get-ItemProperty -path HKLM:\\SOFTWARE\\Mozilla\\ronin_puppet).bootstrap_stage)",
         "If ($stage -ne 'complete') { exit 2}",
         "Set-ItemProperty -Path 'HKLM:\\SOFTWARE\\Mozilla\\ronin_puppet' -name hand_off_ready -type  string -value yes",
-		" # NOTE: the following *3* lines are only needed if the you have installed the Guest Agent.",
-        "  while ((Get-Service RdAgent).Status -ne 'Running') { Start-Sleep -s 5 }",
-        "  while ((Get-Service WindowsAzureTelemetryService).Status -ne 'Running') { Start-Sleep -s 5 }",
-        "  while ((Get-Service WindowsAzureGuestAgent).Status -ne 'Running') { Start-Sleep -s 5 }",
-
-        "if( Test-Path $Env:SystemRoot\\windows\\system32\\Sysprep\\unattend.xml ){ rm $Env:SystemRoot\\windows\\system32\\Sysprep\\unattend.xml -Force}",
+		    "Write-Output '>>> Waiting for GA Service (RdAgent) to start ...'",
+        "while ((Get-Service RdAgent).Status -ne 'Running') { Start-Sleep -s 5 }",
+        "Write-Output '>>> Waiting for GA Service (WindowsAzureTelemetryService) to start ...'",
+        "while ((Get-Service WindowsAzureTelemetryService) -and ((Get-Service WindowsAzureTelemetryService).Status -ne 'Running')) { Start-Sleep -s 5 }",
+        "Write-Output '>>> Waiting for GA Service (WindowsAzureGuestAgent) to start ...'",
+        "while ((Get-Service WindowsAzureGuestAgent).Status -ne 'Running') { Start-Sleep -s 5 }",
+        "Write-Output '>>> Sysprepping VM ...'",
+        "if ( Test-Path $Env:SystemRoot\\system32\\Sysprep\\unattend.xml ) {Remove-Item $Env:SystemRoot\\system32\\Sysprep\\unattend.xml -Force}",
         "& $env:SystemRoot\\System32\\Sysprep\\Sysprep.exe /oobe /generalize /quiet /quit",
-        "while($true) { $imageState = Get-ItemProperty HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Setup\\State | Select ImageState; if($imageState.ImageState -ne 'IMAGE_STATE_GENERALIZE_RESEAL_TO_OOBE') { Write-Output $imageState.ImageState; Start-Sleep -s 10  } else { break } }"
+        "while ($true) { $imageState = (Get-ItemProperty HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Setup\\State).ImageState; Write-Output $imageState; if ($imageState -eq 'IMAGE_STATE_GENERALIZE_RESEAL_TO_OOBE') { break }",
+        "Write-Output '>>> Sysprep complete ...'"
       ]
     }
   ]


### PR DESCRIPTION
To resolve the outstanding issue below, the sysprep script at the end of packer is being changed [based on Microsoft documentation](https://docs.microsoft.com/en-us/azure/virtual-machines/linux/image-builder-json?tabs=azure-powershell#default-sysprep-command) and an outstanding [bug with the way the Windows Agent is handled](https://github.com/hashicorp/packer/issues/9261#issuecomment-632312062)

[Packer plugin tracking issue ](https://github.com/hashicorp/packer/issues/9261)

```Bash
==> azure-arm: Get-Service : Cannot find any service with service name 'WindowsAzureTelemetryService'.
==> azure-arm: At C:\Windows\Temp\script-631a436a-5aac-4d06-ddf3-ca11e039d24d.ps1:6 char:11
==> azure-arm: +   while ((Get-Service WindowsAzureTelemetryService).Status -ne 'Runni ...
==> azure-arm: +           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
==> azure-arm:     + CategoryInfo          : ObjectNotFound: (WindowsAzureTelemetryService:String) [Get-Service], ServiceCommandException
==> azure-arm:     + FullyQualifiedErrorId : NoServiceFoundForGivenName,Microsoft.PowerShell.Commands.GetServiceCommand
==> azure-arm:
```