### PR TITLE
fix: restrict taskcluster tasks to `main` branch

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -14,7 +14,7 @@ tasks:
       else: ${event.repository.html_url}
   in:
     $match:
-      (tasks_for == "github-push"):
+      (tasks_for == "github-push" && event.ref == "refs/heads/main"):
         taskId:
           $eval: as_slugid("decision")
         deadline:


### PR DESCRIPTION
In https://bugzilla.mozilla.org/show_bug.cgi?id=1907217 we're moving away from granting scopes to all branches of a repository. This means that any branches that need scopes should be specified explicitly in https://github.com/mozilla-releng/fxci-config/blob/main/projects.yml.

To avoid confusion, I'm trying to sync up branches that run tasks with branches in projects.yml. As far as I can tell, `main` is the only one that actually ought to run tasks in this repository.